### PR TITLE
[UI] Refactor SettingsScene to Dear ImGui

### DIFF
--- a/src/gui/gui_constants.h
+++ b/src/gui/gui_constants.h
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------------
+//  Football Management Project
+//  Copyright (c) 2025 Flavio Milinanni. All Rights Reserved.
+//
+//  This file is part of the Football Management Project.
+//  See the LICENSE file in the project root.
+// -----------------------------------------------------------------------------
+
+#pragma once
+
+#include <array>
+
+namespace GUIConstants {
+
+  // Button sizes
+  constexpr float BUTTON_WIDTH = 120.0f;
+  constexpr float BUTTON_HEIGHT = 40.0f;
+
+  struct Resolution {
+    int width;
+    int height;
+  };
+
+  constexpr std::array<int, 4> FPS_OPTIONS = {60, 90, 120, 144};
+  constexpr std::array<Resolution, 4> RESOLUTIONS = {
+      Resolution{1280, 720}, Resolution{1920, 1080}, Resolution{2560, 1440}, Resolution{3840, 2160}};
+
+} // namespace GUIConstants

--- a/src/gui/scenes/settings_scene.cpp
+++ b/src/gui/scenes/settings_scene.cpp
@@ -8,146 +8,101 @@
 
 #include "settings_scene.h"
 
+#include <imgui.h>
 #include <algorithm>
-#include <iostream>
 
 #include "global/paths.h"
-#include "gui/dropdown.h"
-#include "gui/gui_view.h"
-#include "main_menu_scene.h"
+#include "gui/gui_constants.h"
 #include "settings_manager.h"
+#include "gui/scenes/main_menu_scene.h"
 
 SceneID SettingsScene::getID() const { return SceneID::SETTINGS; }
 
-SettingsScene::SettingsScene(GUIView* guiView_ptr) : GUIScene(guiView_ptr), font(nullptr) {}
-
-SettingsScene::~SettingsScene()
-{
-  // unique_ptrs and onExit
-  // will handle cleanup
-}
+SettingsScene::SettingsScene(GUIView* guiView_ptr) : GUIScene(guiView_ptr) {}
 
 void SettingsScene::onEnter()
 {
-  if (!TTF_WasInit() && TTF_Init() != 0)
-  {
-    std::cerr << "TTF_Init() failed: " << SDL_GetError() << "\n";
-    return;
-  }
-
-  font = TTF_OpenFont(FONT_PATH, 24);
-  if (!font)
-  {
-    std::cerr << "Failed to load font: " << SDL_GetError() << "\n";
-    return;
-  }
-
-  buttonManager = std::make_unique<ButtonManager>(getRenderer(), font);
-
-  for (const auto& [lang, str] : languageToString)
-  {
+  languageOptions.clear();
+  availableLanguageEnums.clear();
+  for (const auto& [lang, str] : languageToString) {
     languageOptions.push_back(str);
+    availableLanguageEnums.push_back(lang);
   }
-  for (const auto& res : resolutions)
-  {
-    resolutionOptions.push_back(std::to_string(res.first) + "x" + std::to_string(res.second));
+  for (const auto& res : GUIConstants::RESOLUTIONS) {
+    resolutionOptions.push_back(std::to_string(res.width) + "x" + std::to_string(res.height));
   }
-  for (const auto& fps : fpsOptions)
-  {
-    fpsOptionsStrings.push_back(std::to_string(fps));
-  }
+  for (const auto& fps : GUIConstants::FPS_OPTIONS) { fpsOptionsStrings.push_back(std::to_string(fps)); }
 
-  initializeCurrentSelections();
-  createLabelTextures();
-
-  float dropdownX = 350.0f;
-  float dropdownY = 200.0f;
-  float dropdownW = 300.0f;
-  float dropdownH = 40.0f;
-  float paddingY = 60.0f;
-
-  languageDropdown = std::make_shared<Dropdown>(
-      getRenderer(), font, SDL_FRect{dropdownX, dropdownY, dropdownW, dropdownH}, languageOptions);
-  languageDropdown->setOnSelectionChanged(
-      [this](int index, const std::string& value)
-      {
-        (void)value;
-        selectedLanguage = index;
-      });
-  languageDropdown->setSelectedIndex(selectedLanguage);
-
-  dropdownY += paddingY;
-  resolutionDropdown = std::make_shared<Dropdown>(
-      getRenderer(), font, SDL_FRect{dropdownX, dropdownY, dropdownW, dropdownH},
-      resolutionOptions);
-  resolutionDropdown->setOnSelectionChanged(
-      [this](int index, const std::string& value)
-      {
-        (void)value;
-        selectedResolution = index;
-      });
-  resolutionDropdown->setSelectedIndex(selectedResolution);
-
-  dropdownY += paddingY;
-  fpsDropdown = std::make_shared<Dropdown>(getRenderer(), font,
-                                           SDL_FRect{dropdownX, dropdownY, dropdownW, dropdownH},
-                                           fpsOptionsStrings);
-  fpsDropdown->setOnSelectionChanged(
-      [this](int index, const std::string& value)
-      {
-        (void)value;
-        selectedFPS = index;
-      });
-  fpsDropdown->setSelectedIndex(selectedFPS);
-
-  dropdownY += paddingY + 10.0f;
-  std::string fullscreenText = fullscreen ? "Fullscreen: ON" : "Fullscreen: OFF";
-  fullscreenButtonId = buttonManager->addButton(
-      dropdownX, dropdownY, dropdownW, dropdownH, fullscreenText,
-      [this]()
-      {
-        fullscreen = !fullscreen;
-        buttonManager->setButtonText(fullscreenButtonId,
-                                     fullscreen ? "Fullscreen: ON" : "Fullscreen: OFF");
-        buttonManager->setButtonStyle(
-            fullscreenButtonId, fullscreen ? getSelectedButtonStyle() : getDefaultButtonStyle());
-      });
-  buttonManager->setButtonStyle(fullscreenButtonId,
-                                fullscreen ? getSelectedButtonStyle() : getDefaultButtonStyle());
-
-  dropdownY += paddingY;
-  float cancelX = 250.0f;
-  float buttonW = 200.0f;
-  buttonManager->addButton(cancelX, dropdownY, buttonW, dropdownH, "Cancel",
-                           [this]() { changeScene(std::make_unique<MainMenuScene>(guiView)); });
-
-  applyButtonId = buttonManager->addButton(cancelX + buttonW + 20, dropdownY, buttonW, dropdownH,
-                                           "Apply & Back", [this]() { applyAndSaveSettings(); });
-}
-
-void SettingsScene::initializeCurrentSelections()
-{
   SettingsManager* settingsManager = SettingsManager::instance();
   const auto& settings = settingsManager->getSettings();
 
-  auto itLang = std::find_if(languageToString.begin(), languageToString.end(),
-                             [&](const auto& kv) { return kv.first == settings.language; });
-  selectedLanguage = (itLang != languageToString.end())
-                         ? static_cast<int>(std::distance(languageToString.begin(), itLang))
-                         : 0;
+  auto itLang = std::find(availableLanguageEnums.begin(), availableLanguageEnums.end(), settings.language);
+  selectedLanguage = (itLang != availableLanguageEnums.end()) ? static_cast<int>(std::distance(availableLanguageEnums.begin(), itLang)) : 0;
 
-  auto itFps = std::find(fpsOptions.begin(), fpsOptions.end(), settings.fps_limit);
-  selectedFPS =
-      (itFps != fpsOptions.end()) ? static_cast<int>(std::distance(fpsOptions.begin(), itFps)) : 0;
+  auto itFps = std::find(GUIConstants::FPS_OPTIONS.begin(), GUIConstants::FPS_OPTIONS.end(), settings.fps_limit);
+  selectedFPS = (itFps != GUIConstants::FPS_OPTIONS.end()) ? static_cast<int>(std::distance(GUIConstants::FPS_OPTIONS.begin(), itFps)) : 0;
 
-  auto itRes = std::find_if(
-      resolutions.begin(), resolutions.end(), [&](const auto& r)
-      { return r.first == settings.resolution_width && r.second == settings.resolution_height; });
-  selectedResolution = (itRes != resolutions.end())
-                           ? static_cast<int>(std::distance(resolutions.begin(), itRes))
-                           : 0;
+  auto itRes = std::find_if(GUIConstants::RESOLUTIONS.begin(), GUIConstants::RESOLUTIONS.end(), [&](const auto& r) {
+    return r.width == settings.resolution_width && r.height == settings.resolution_height;
+  });
+  selectedResolution = (itRes != GUIConstants::RESOLUTIONS.end()) ? static_cast<int>(std::distance(GUIConstants::RESOLUTIONS.begin(), itRes)) : 0;
 
   fullscreen = settings.fullscreen;
+}
+
+void SettingsScene::update(float deltaTime) { (void)deltaTime; }
+
+void SettingsScene::render()
+{
+  ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+  ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize);
+
+  ImGui::Text("Settings");
+  ImGui::Separator();
+  ImGui::Spacing();
+
+  if (ImGui::BeginCombo("Language", languageOptions[selectedLanguage].c_str())) {
+    for (size_t i = 0; i < languageOptions.size(); i++) {
+      bool is_selected = (static_cast<size_t>(selectedLanguage) == i);
+      if (ImGui::Selectable(languageOptions[i].c_str(), is_selected)) selectedLanguage = static_cast<int>(i);
+      if (is_selected) ImGui::SetItemDefaultFocus();
+    }
+    ImGui::EndCombo();
+  }
+
+  if (ImGui::BeginCombo("Resolution", resolutionOptions[selectedResolution].c_str())) {
+    for (size_t i = 0; i < resolutionOptions.size(); i++) {
+      bool is_selected = (static_cast<size_t>(selectedResolution) == i);
+      if (ImGui::Selectable(resolutionOptions[i].c_str(), is_selected)) selectedResolution = static_cast<int>(i);
+      if (is_selected) ImGui::SetItemDefaultFocus();
+    }
+    ImGui::EndCombo();
+  }
+
+  if (ImGui::BeginCombo("Refresh Rate", fpsOptionsStrings[selectedFPS].c_str())) {
+    for (size_t i = 0; i < fpsOptionsStrings.size(); i++) {
+      bool is_selected = (static_cast<size_t>(selectedFPS) == i);
+      if (ImGui::Selectable(fpsOptionsStrings[i].c_str(), is_selected)) selectedFPS = static_cast<int>(i);
+      if (is_selected) ImGui::SetItemDefaultFocus();
+    }
+    ImGui::EndCombo();
+  }
+
+  ImGui::Checkbox("Fullscreen", &fullscreen);
+
+  ImGui::Spacing();
+  ImGui::Separator();
+  ImGui::Spacing();
+
+  if (ImGui::Button("Cancel", ImVec2(GUIConstants::BUTTON_WIDTH, GUIConstants::BUTTON_HEIGHT))) {
+    changeScene(std::make_unique<MainMenuScene>(guiView));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Apply", ImVec2(GUIConstants::BUTTON_WIDTH, GUIConstants::BUTTON_HEIGHT))) {
+    applyAndSaveSettings();
+  }
+
+  ImGui::End();
 }
 
 void SettingsScene::applyAndSaveSettings()
@@ -155,19 +110,17 @@ void SettingsScene::applyAndSaveSettings()
   SettingsManager* settingsManager = SettingsManager::instance();
   auto& settings = settingsManager->getSettings();
 
-  auto langIt = languageToString.begin();
-  std::advance(langIt, selectedLanguage);
-  settings.language = langIt->first;
-
-  if (selectedFPS >= 0 && selectedFPS < static_cast<int>(fpsOptions.size()))
-  {
-    settings.fps_limit = fpsOptions[static_cast<std::size_t>(selectedFPS)];
+  if (selectedLanguage >= 0 && selectedLanguage < static_cast<int>(availableLanguageEnums.size())) {
+    settings.language = availableLanguageEnums[static_cast<std::size_t>(selectedLanguage)];
   }
 
-  if (selectedResolution >= 0 && selectedResolution < static_cast<int>(resolutions.size()))
-  {
-    settings.resolution_width = resolutions[static_cast<std::size_t>(selectedResolution)].first;
-    settings.resolution_height = resolutions[static_cast<std::size_t>(selectedResolution)].second;
+  if (selectedFPS >= 0 && selectedFPS < static_cast<int>(GUIConstants::FPS_OPTIONS.size())) {
+    settings.fps_limit = GUIConstants::FPS_OPTIONS[static_cast<std::size_t>(selectedFPS)];
+  }
+
+  if (selectedResolution >= 0 && selectedResolution < static_cast<int>(GUIConstants::RESOLUTIONS.size())) {
+    settings.resolution_width = GUIConstants::RESOLUTIONS[static_cast<std::size_t>(selectedResolution)].width;
+    settings.resolution_height = GUIConstants::RESOLUTIONS[static_cast<std::size_t>(selectedResolution)].height;
   }
   settings.fullscreen = fullscreen;
 
@@ -175,204 +128,4 @@ void SettingsScene::applyAndSaveSettings()
   settingsManager->save();
 
   changeScene(std::make_unique<MainMenuScene>(guiView));
-}
-
-void SettingsScene::handleEvent(const SDL_Event& event)
-{
-  // Motion events are passed to both buttons and open dropdowns
-  if (event.type == SDL_EVENT_MOUSE_MOTION)
-  {
-    if (buttonManager)
-    {
-      buttonManager->handleMouseMove(event.motion.x, event.motion.y);
-    }
-    if (activeDropdown && activeDropdown->isDropdownOpen())
-    {
-      activeDropdown->handleEvent(event);
-    }
-    return;
-  }
-
-  // Click events require careful handling
-  if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
-  {
-    // If a dropdown is open, it gets exclusive priority
-    if (activeDropdown && activeDropdown->isDropdownOpen())
-    {
-      activeDropdown->handleEvent(event);
-      // After handling, the dropdown might have closed.
-      // If it's now closed, we check if it was because the user clicked outside.
-      // The dropdown's handleEvent should return true if it handled the click (selection or
-      // closing). This prevents the click from passing through to buttons underneath.
-      if (!activeDropdown->isDropdownOpen())
-      {
-        activeDropdown = nullptr;
-      }
-      return;  // The click is consumed by the dropdown logic
-    }
-
-    // If no dropdown is open, check if a click opens one
-    if (languageDropdown->handleEvent(event))
-    {
-      activeDropdown = languageDropdown;
-      resolutionDropdown->close();
-      fpsDropdown->close();
-      return;
-    }
-    if (resolutionDropdown->handleEvent(event))
-    {
-      activeDropdown = resolutionDropdown;
-      languageDropdown->close();
-      fpsDropdown->close();
-      return;
-    }
-    if (fpsDropdown->handleEvent(event))
-    {
-      activeDropdown = fpsDropdown;
-      languageDropdown->close();
-      resolutionDropdown->close();
-      return;
-    }
-
-    // If no dropdown was opened or interacted with, check buttons
-    if (buttonManager)
-    {
-      buttonManager->handleMouseClick(event.button.x, event.button.y);
-    }
-  }
-
-  if (event.type == SDL_EVENT_KEY_DOWN &&
-      (event.key.key == SDLK_ESCAPE || event.key.key == SDLK_BACKSPACE))
-  {
-    changeScene(std::make_unique<MainMenuScene>(guiView));
-  }
-}
-
-void SettingsScene::update(float deltaTime) { (void)deltaTime; }
-
-void SettingsScene::render()
-{
-  SDL_SetRenderDrawColor(getRenderer(), 30, 30, 30, 255);
-  SDL_RenderClear(getRenderer());
-
-  if (titleTexture)
-  {
-    SDL_RenderTexture(getRenderer(), titleTexture, nullptr, &titleRect);
-  }
-  if (buttonManager)
-  {
-    buttonManager->render();
-  }
-
-  if (langLabelTexture)
-  {
-    SDL_RenderTexture(getRenderer(), langLabelTexture, nullptr, &langLabelRect);
-  }
-  if (resLabelTexture)
-  {
-    SDL_RenderTexture(getRenderer(), resLabelTexture, nullptr, &resLabelRect);
-  }
-  if (fpsLabelTexture)
-  {
-    SDL_RenderTexture(getRenderer(), fpsLabelTexture, nullptr, &fpsLabelRect);
-  }
-
-  // Render non-active dropdowns first
-  if (languageDropdown != activeDropdown) languageDropdown->render();
-  if (resolutionDropdown != activeDropdown) resolutionDropdown->render();
-  if (fpsDropdown != activeDropdown) fpsDropdown->render();
-
-  // Render active dropdown last so it's on top
-  if (activeDropdown) activeDropdown->render();
-}
-
-void SettingsScene::onExit()
-{
-  freeLabelTextures();
-  if (font)
-  {
-    TTF_CloseFont(font);
-    font = nullptr;
-  }
-}
-
-void SettingsScene::createLabelTextures()
-{
-  SDL_Color color = {255, 255, 255, 255};
-  float w, h;
-  float yPos = 200.0f;
-
-  // Title
-  SDL_Surface* surf = TTF_RenderText_Blended(font, "Settings", 0, color);
-  titleTexture = SDL_CreateTextureFromSurface(getRenderer(), surf);
-  SDL_GetTextureSize(titleTexture, &w, &h);
-  int win_w, win_h;
-  SDL_GetWindowSizeInPixels(guiView->getWindow(), &win_w, &win_h);
-  titleRect = {(static_cast<float>(win_w) / 2 - w / 2), 100.0f, w, h};
-  SDL_DestroySurface(surf);
-
-  // Labels
-  surf = TTF_RenderText_Blended(font, "Language", 0, color);
-  langLabelTexture = SDL_CreateTextureFromSurface(getRenderer(), surf);
-  SDL_GetTextureSize(langLabelTexture, &w, &h);
-  langLabelRect = {200.0f, yPos + 10, w, h};
-  SDL_DestroySurface(surf);
-
-  yPos += 60.0f;
-  surf = TTF_RenderText_Blended(font, "Resolution", 0, color);
-  resLabelTexture = SDL_CreateTextureFromSurface(getRenderer(), surf);
-  SDL_GetTextureSize(resLabelTexture, &w, &h);
-  resLabelRect = {200.0f, yPos + 10, w, h};
-  SDL_DestroySurface(surf);
-
-  yPos += 60.0f;
-  surf = TTF_RenderText_Blended(font, "Refresh Rate", 0, color);
-  fpsLabelTexture = SDL_CreateTextureFromSurface(getRenderer(), surf);
-  SDL_GetTextureSize(fpsLabelTexture, &w, &h);
-  fpsLabelRect = {200.0f, yPos + 10, w, h};
-  SDL_DestroySurface(surf);
-}
-
-void SettingsScene::freeLabelTextures()
-{
-  if (titleTexture)
-  {
-    SDL_DestroyTexture(titleTexture);
-    titleTexture = nullptr;
-  }
-  if (langLabelTexture)
-  {
-    SDL_DestroyTexture(langLabelTexture);
-    langLabelTexture = nullptr;
-  }
-  if (resLabelTexture)
-  {
-    SDL_DestroyTexture(resLabelTexture);
-    resLabelTexture = nullptr;
-  }
-  if (fpsLabelTexture)
-  {
-    SDL_DestroyTexture(fpsLabelTexture);
-    fpsLabelTexture = nullptr;
-  }
-}
-
-ButtonStyle SettingsScene::getDefaultButtonStyle()
-{
-  ButtonStyle style;
-  style.backgroundColor = {60, 60, 60, 255};
-  style.textColor = {255, 255, 255, 255};
-  style.borderColor = {100, 100, 100, 255};
-  style.hasBorder = true;
-  return style;
-}
-
-ButtonStyle SettingsScene::getSelectedButtonStyle()
-{
-  ButtonStyle style;
-  style.backgroundColor = {80, 120, 80, 255};
-  style.textColor = {255, 255, 255, 255};
-  style.borderColor = {120, 180, 120, 255};
-  style.hasBorder = true;
-  return style;
 }

--- a/src/gui/scenes/settings_scene.h
+++ b/src/gui/scenes/settings_scene.h
@@ -7,71 +7,34 @@
 // -----------------------------------------------------------------------------
 
 #pragma once
-#include <SDL3/SDL.h>
-#include <SDL3_ttf/SDL_ttf.h>
-
-#include <array>
-#include <memory>
-#include <utility>
-#include <vector>
-
-#include "gui/button_manager.h"
-#include "gui/dropdown.h"
 #include "gui/gui_scene.h"
 #include "gui/gui_view.h"
+#include <string>
+#include <vector>
+#include <utility>
+#include <array>
 
 class SettingsScene : public GUIScene
 {
  public:
   explicit SettingsScene(GUIView* guiView_ptr);
-  ~SettingsScene();
-  void handleEvent(const SDL_Event& event) override;
+  ~SettingsScene() = default;
+
   void update(float deltaTime) override;
   void render() override;
   void onEnter() override;
-  void onExit() override;
   SceneID getID() const override;
 
  private:
-  TTF_Font* font;
-  std::unique_ptr<ButtonManager> buttonManager;
+  void applyAndSaveSettings();
 
-  // New dropdowns
-  std::shared_ptr<Dropdown> languageDropdown;
-  std::shared_ptr<Dropdown> resolutionDropdown;
-  std::shared_ptr<Dropdown> fpsDropdown;
-  std::shared_ptr<Dropdown> activeDropdown = nullptr;
-
-  // Options
   std::vector<std::string> languageOptions;
+  std::vector<Language> availableLanguageEnums;
   std::vector<std::string> resolutionOptions;
   std::vector<std::string> fpsOptionsStrings;
-  std::array<int, 4> fpsOptions = {60, 90, 120, 144};
-  std::array<std::pair<int, int>, 4> resolutions = {
-      {{1280, 720}, {1920, 1080}, {2560, 1440}, {3840, 2160}}};
 
-  // Current selections
   int selectedLanguage = 0;
   int selectedFPS = 0;
   int selectedResolution = 0;
   bool fullscreen = false;
-
-  int fullscreenButtonId = -1;
-  int applyButtonId = -1;
-
-  // Helper methods
-  void initializeCurrentSelections();
-  void applyAndSaveSettings();
-  void createLabelTextures();
-  void freeLabelTextures();
-
-  ButtonStyle getDefaultButtonStyle();
-  ButtonStyle getSelectedButtonStyle();
-
-  // Cached Textures
-  SDL_Texture* titleTexture = nullptr;
-  SDL_Texture* langLabelTexture = nullptr;
-  SDL_Texture* resLabelTexture = nullptr;
-  SDL_Texture* fpsLabelTexture = nullptr;
-  SDL_FRect titleRect{}, langLabelRect{}, resLabelRect{}, fpsLabelRect{};
 };


### PR DESCRIPTION
Resolves #4

This PR specifically addresses the ImGui migration for the Settings Scene. 
- Fully ports the `SettingsScene` rendering logic and events to Dear ImGui.
- Extracts magic numbers (like Resolutions and FPS options) into `gui_constants.h`.
- Cleanly integrates with the base ImGui architecture from the Epic PR.