### PR TITLE
build: fix deprecated SQLite3 target warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ if(NOT SQLite3_FOUND)
     GIT_TAG        v3.45.1.0
   )
   FetchContent_MakeAvailable(sqlite3)
-  if(NOT TARGET SQLite::SQLite3)
-    add_library(SQLite::SQLite3 ALIAS sqlite3)
+  if(NOT TARGET SQLite3::SQLite3)
+    add_library(SQLite3::SQLite3 ALIAS sqlite3)
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ target_link_libraries(core_lib PUBLIC
   fmt::fmt
   spdlog::spdlog
   nlohmann_json::nlohmann_json
-  SQLite::SQLite3
+  SQLite3::SQLite3
   SDL3::SDL3
   SDL3_ttf::SDL3_ttf
 )


### PR DESCRIPTION
Replaces the deprecated `SQLite::SQLite3` target with `SQLite3::SQLite3` to resolve the CMake warning.