### PR TITLE
[Performance] Add benchmarks for data loading and saving

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -25,6 +25,7 @@ You MUST adhere to our linting and formatting rules:
 2. **Linting:** We strictly enforce `.clang-tidy`. Ensure your changes do not introduce warnings.
 3. **Scoped Variables:** Keep variables scoped tightly, inside `if` statements if they are not used elsewhere.
 4. **Headers:** We use `#pragma once` as our include guard.
+5. **Performance Testing:** Any code modifying core performance (like Database IO) MUST run benchmarks locally. These are disabled in CI. Configure with `-DBUILD_BENCHMARKS=ON` and run `./build/benchmarks/db_benchmarks`. Report the results to the user.
 
 ## 5. GitHub Traceability Protocol
 Before starting a major implementation, the agent should:
@@ -38,4 +39,4 @@ As an AI Agent, you must comply with [AI_GUIDELINES.md](AI_GUIDELINES.md):
 1. **Declare your usage:** Make sure any Pull Request clearly states that it was agent-generated and describes the steps you took.
 2. **Request Review:** You MUST request human review on architectural decisions and complex logic  BEFORE pushing. Do not bypass the human user.
 3. **Document Your Work:** Utilize plan artifacts and walkthroughs to summarize your goals and accomplishments.
-4. **Never Push:** ONLY USERS can push to remote branches! The agent must NEVER run `git push`. The agent should only create commits and then let the user review and push them manually.
+4. **Never Commit or Push:** ONLY USERS can create commits and push to remote branches! The agent must NEVER run `git commit` or `git push`. The agent should only `git add` relevant files and let the user review and commit them manually.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,19 @@ if(BUILD_TESTING)
   FetchContent_MakeAvailable(googletest)
 endif()
 
+# Google Benchmark
+option(BUILD_BENCHMARKS "Build benchmarks" ON)
+if(BUILD_BENCHMARKS)
+  FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        v1.8.3
+    GIT_SHALLOW    TRUE
+  )
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable benchmark tests" FORCE)
+  set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Disable benchmark install" FORCE)
+  FetchContent_MakeAvailable(benchmark)
+endif()
 # -----------------------------
 # Subdirectories
 # -----------------------------
@@ -151,6 +164,11 @@ if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()
+
+if(BUILD_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()
+
 
 # -----------------------------
 # Tools & Formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,21 @@ First off, thank you for considering contributing to Football Management! It's p
    ctest --test-dir build -V
    ```
 
+## Performance Benchmarks
+
+If your Pull Request introduces changes that might affect the game's performance (such as database IO, tight game loops, etc.), you **MUST** run the benchmarks locally. Note that these benchmarks are *not* run in CI to save resources and avoid flakiness.
+
+To run the benchmarks:
+```bash
+# Configure the build with benchmarks enabled
+cmake -S . -B build -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+# Build the benchmarks
+cmake --build build --target db_benchmarks
+# Execute the benchmarks
+./build/benchmarks/db_benchmarks
+```
+Please include the benchmark output in your Pull Request description.
+
 ## Branching Strategy
 
 - **Main branch:** `main` is our bleeding edge. It should always compile and pass all tests.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(db_benchmarks
+  db_benchmark.cpp
+)
+
+target_link_libraries(db_benchmarks
+  PRIVATE
+    core_lib
+    benchmark::benchmark_main
+)
+
+target_include_directories(db_benchmarks
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)

--- a/benchmarks/db_benchmark.cpp
+++ b/benchmarks/db_benchmark.cpp
@@ -10,13 +10,16 @@
 // Set up the database environment for benchmarks
 class DatabaseFixture : public benchmark::Fixture {
  public:
-  void SetUp(const ::benchmark::State& state) {
+  void SetUp(const ::benchmark::State& state) override {
     (void)state;
+    // Remove the database file to ensure a clean slate for each benchmark run
+    std::filesystem::remove(DATABASE_PATH);
+    
     db = std::make_shared<Database>();
     db->initialize();
   }
 
-  void TearDown(const ::benchmark::State& state) {
+  void TearDown(const ::benchmark::State& state) override {
     (void)state;
     db.reset();
   }
@@ -25,18 +28,51 @@ class DatabaseFixture : public benchmark::Fixture {
 };
 
 BENCHMARK_DEFINE_F(DatabaseFixture, BM_LoadFromDB)(benchmark::State& state) {
-  for (auto _ : state) { GameData::instance().loadFromDB(db); }
+  state.PauseTiming();
+  // Pre-load initial data
+  GameData::instance().loadFromDB(db);
+
+  int target_players = state.range(0);
+  int current_players = GameData::instance().getPlayers().size();
+  
+  // Inject extra players directly into the DB
+  for (int i = current_players; i < target_players; ++i) {
+      Player p(i, 1, "Test", "Player " + std::to_string(i), "ST", 
+               Language::EN, 1000, 0, 20, 2, 180, Foot::Right, {});
+      db->insertPlayer(p);
+  }
+  state.ResumeTiming();
+
+  for (auto _ : state) { 
+      (void)_;
+      GameData::instance().loadFromDB(db); 
+  }
 }
 
 BENCHMARK_DEFINE_F(DatabaseFixture, BM_SaveToDB)(benchmark::State& state) {
-  // Pre-load data so we have something to save
+  state.PauseTiming();
+  // Pre-load data
   GameData::instance().loadFromDB(db);
 
-  for (auto _ : state) { GameData::instance().saveToDB(); }
+  int target_players = state.range(0);
+  int current_players = GameData::instance().getPlayers().size();
+  
+  for (int i = current_players; i < target_players; ++i) {
+      Player p(i, 1, "Test", "Player " + std::to_string(i), "ST", 
+               Language::EN, 1000, 0, 20, 2, 180, Foot::Right, {});
+      db->insertPlayer(p);
+      GameData::instance().addPlayer(p.getId(), p);
+  }
+  state.ResumeTiming();
+
+  for (auto _ : state) { 
+      (void)_;
+      GameData::instance().saveToDB(); 
+  }
 }
 
-// Register the functions as a benchmark
-BENCHMARK_REGISTER_F(DatabaseFixture, BM_LoadFromDB)->Unit(benchmark::kMillisecond);
-BENCHMARK_REGISTER_F(DatabaseFixture, BM_SaveToDB)->Unit(benchmark::kMillisecond);
+// Register the functions as a benchmark and test scaling from 512 to 4096 players
+BENCHMARK_REGISTER_F(DatabaseFixture, BM_LoadFromDB)->RangeMultiplier(2)->Range(512, 4096)->Unit(benchmark::kMillisecond);
+BENCHMARK_REGISTER_F(DatabaseFixture, BM_SaveToDB)->RangeMultiplier(2)->Range(512, 4096)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/benchmarks/db_benchmark.cpp
+++ b/benchmarks/db_benchmark.cpp
@@ -1,0 +1,42 @@
+#include <benchmark/benchmark.h>
+
+#include <filesystem>
+#include <memory>
+
+#include "database/database.h"
+#include "database/gamedata.h"
+#include "global/paths.h"
+
+// Set up the database environment for benchmarks
+class DatabaseFixture : public benchmark::Fixture {
+ public:
+  void SetUp(const ::benchmark::State& state) {
+    (void)state;
+    db = std::make_shared<Database>();
+    db->initialize();
+  }
+
+  void TearDown(const ::benchmark::State& state) {
+    (void)state;
+    db.reset();
+  }
+
+  std::shared_ptr<Database> db;
+};
+
+BENCHMARK_DEFINE_F(DatabaseFixture, BM_LoadFromDB)(benchmark::State& state) {
+  for (auto _ : state) { GameData::instance().loadFromDB(db); }
+}
+
+BENCHMARK_DEFINE_F(DatabaseFixture, BM_SaveToDB)(benchmark::State& state) {
+  // Pre-load data so we have something to save
+  GameData::instance().loadFromDB(db);
+
+  for (auto _ : state) { GameData::instance().saveToDB(); }
+}
+
+// Register the functions as a benchmark
+BENCHMARK_REGISTER_F(DatabaseFixture, BM_LoadFromDB)->Unit(benchmark::kMillisecond);
+BENCHMARK_REGISTER_F(DatabaseFixture, BM_SaveToDB)->Unit(benchmark::kMillisecond);
+
+BENCHMARK_MAIN();

--- a/src/database/gamedata.cpp
+++ b/src/database/gamedata.cpp
@@ -17,38 +17,32 @@
 #include "global/logger.h"
 #include "global/paths.h"
 
-GameData& GameData::instance()
-{
+GameData& GameData::instance() {
   static GameData instance;
   return instance;
 }
 
-GameData::GameData()
-{
+GameData::GameData() {
   // Constructor is kept empty, initialization is done in loadFromDB
 }
 
 // ---------------- DB ----------------
-bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr)
-{
+bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr) {
   loadStatsConfig();
   db = database_ptr;
   bool is_first_run = db->isFirstRun();
 
-  Logger::debug("GameData::loadFromDB called. is_first_run: " +
-                std::to_string(is_first_run));
+  Logger::debug("GameData::loadFromDB called. is_first_run: " + std::to_string(is_first_run));
 
   std::vector<Team> all_teams;
-  if (is_first_run)
-  {
+  if (is_first_run) {
     database_ptr->initialize();
     Logger::debug("Database initialized. Generating data.");
 
     auto leagues_data = DataGenerator::generateLeagues();
     all_teams = DataGenerator::generateTeams();
 
-    for (const auto& team : all_teams)
-    {
+    for (const auto& team : all_teams) {
       database_ptr->insertTeamWithId(team);
       _teams.emplace(team.getId(), team);
     }
@@ -56,44 +50,33 @@ bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr)
     for (auto& p : _teams) _teamsVec.push_back(p.second);
 
     std::map<uint8_t, std::vector<TeamID>> league_teams_map;
-    for (const auto& team : all_teams)
-    {
+    for (const auto& team : all_teams) {
       league_teams_map[team.getLeagueId()].push_back(team.getId());
     }
 
-    for (const auto& league_data : leagues_data)
-    {
+    for (const auto& league_data : leagues_data) {
       database_ptr->insertLeagueWithId(league_data);
-      _leagues.emplace(league_data.getId(),
-                       League(league_data.getId(), league_data.getName(),
-                              league_teams_map[league_data.getId()]));
+      _leagues.emplace(league_data.getId(), League(league_data.getId(), league_data.getName(),
+                                                   league_teams_map[league_data.getId()]));
     }
 
     auto players = DataGenerator::generatePlayers();
-    for (const auto& player : players)
-    {
+    for (const auto& player : players) {
       database_ptr->insertPlayer(player);
       _players.emplace(player.getId(), player);
     }
-  }
-  else
-  {
+  } else {
     auto leagues_from_db = database_ptr->loadAllLeagues();
     all_teams = database_ptr->loadAllTeams();
 
-    for (const auto& team : all_teams)
-    {
-      _teams.emplace(team.getId(), team);
-    }
+    for (const auto& team : all_teams) { _teams.emplace(team.getId(), team); }
 
     std::map<uint8_t, std::vector<TeamID>> league_teams_map;
-    for (const auto& team : all_teams)
-    {
+    for (const auto& team : all_teams) {
       league_teams_map[team.getLeagueId()].push_back(team.getId());
     }
 
-    for (const auto& league_from_db : leagues_from_db)
-    {
+    for (const auto& league_from_db : leagues_from_db) {
       _leagues.emplace(league_from_db.getId(),
                        League(league_from_db.getId(), league_from_db.getName(),
                               league_teams_map[league_from_db.getId()]));
@@ -101,10 +84,7 @@ bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr)
     }
 
     auto players = database_ptr->loadAllPlayers();
-    for (const auto& player : players)
-    {
-      _players.emplace(player.getId(), player);
-    }
+    for (const auto& player : players) { _players.emplace(player.getId(), player); }
     Logger::debug("Loaded all data from database.");
   }
 
@@ -124,152 +104,111 @@ bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr)
   return true;
 }
 
+bool GameData::saveToDB() const {
+  if (!db) return false;
+
+  for (const auto& player_ref : _playersVec) { db->updatePlayer(player_ref.get()); }
+
+  return true;
+}
+
 // ---------------- League ----------------
-void GameData::addLeague(LeagueID id, const League& league)
-{
+void GameData::addLeague(LeagueID id, const League& league) {
   _leagues.emplace(id, league);
   if (!_leaguesVec.empty()) _leaguesVec.push_back(_leagues.at(id));
 }
 
-std::optional<std::reference_wrapper<const League>> GameData::getLeague(
-    LeagueID id) const
-{
+std::optional<std::reference_wrapper<const League>> GameData::getLeague(LeagueID id) const {
   if (auto it = _leagues.find(id); it != _leagues.end()) return it->second;
   return std::nullopt;
 }
 
-const std::unordered_map<LeagueID, League>& GameData::getLeagues() const
-{
-  return _leagues;
-}
+const std::unordered_map<LeagueID, League>& GameData::getLeagues() const { return _leagues; }
 
-std::unordered_map<LeagueID, League>& GameData::getLeagues()
-{
-  return _leagues;
-}
+std::unordered_map<LeagueID, League>& GameData::getLeagues() { return _leagues; }
 
-const std::vector<std::reference_wrapper<const League>>&
-GameData::getLeaguesVector() const
-{
+const std::vector<std::reference_wrapper<const League>>& GameData::getLeaguesVector() const {
   return _leaguesVec;
 }
 
 // ---------------- Team ----------------
-void GameData::addTeam(TeamID id, const Team& team)
-{
+void GameData::addTeam(TeamID id, const Team& team) {
   _teams.emplace(id, team);
   if (!_teamsVec.empty()) _teamsVec.push_back(_teams.at(id));
 }
 
-std::optional<std::reference_wrapper<Team>> GameData::getTeam(TeamID id)
-{
+std::optional<std::reference_wrapper<Team>> GameData::getTeam(TeamID id) {
   if (auto it = _teams.find(id); it != _teams.end()) return it->second;
   return std::nullopt;
 }
 
-std::optional<std::reference_wrapper<const Team>> GameData::getTeam(
-    TeamID id) const
-{
+std::optional<std::reference_wrapper<const Team>> GameData::getTeam(TeamID id) const {
   if (auto it = _teams.find(id); it != _teams.end()) return it->second;
   return std::nullopt;
 }
 
-const std::unordered_map<TeamID, Team>& GameData::getTeams() const
-{
-  return _teams;
-}
+const std::unordered_map<TeamID, Team>& GameData::getTeams() const { return _teams; }
 
 std::unordered_map<TeamID, Team>& GameData::getTeams() { return _teams; }
 
-const std::vector<std::reference_wrapper<const Team>>&
-GameData::getTeamsVector() const
-{
+const std::vector<std::reference_wrapper<const Team>>& GameData::getTeamsVector() const {
   return _teamsVec;
 }
 
 // ---------------- Player ----------------
-void GameData::addPlayer(PlayerID id, const Player& player)
-{
+void GameData::addPlayer(PlayerID id, const Player& player) {
   _players.emplace(id, player);
-  if (!_playersVec.empty()) _playersVec.push_back(_players.at(id));
+  if (!_playersVec.empty()) { _playersVec.push_back(_players.at(id)); }
 }
 
-std::optional<std::reference_wrapper<const Player>> GameData::getPlayer(
-    PlayerID id) const
-{
+std::optional<std::reference_wrapper<const Player>> GameData::getPlayer(PlayerID id) const {
   if (auto it = _players.find(id); it != _players.end()) return it->second;
   return std::nullopt;
 }
 
-const std::unordered_map<PlayerID, Player>& GameData::getPlayers() const
-{
-  return _players;
-}
+const std::unordered_map<PlayerID, Player>& GameData::getPlayers() const { return _players; }
 
-std::unordered_map<PlayerID, Player>& GameData::getPlayers()
-{
-  return _players;
-}
-const std::vector<std::reference_wrapper<const Player>>&
-GameData::getPlayersVector() const
-{
+std::unordered_map<PlayerID, Player>& GameData::getPlayers() { return _players; }
+const std::vector<std::reference_wrapper<const Player>>& GameData::getPlayersVector() const {
   return _playersVec;
 }
 
-void GameData::ageAllPlayers()
-{
-  for (auto& pair : _players)
-  {
-    pair.second.agePlayer();
-  }
+void GameData::ageAllPlayers() {
+  for (auto& pair : _players) { pair.second.agePlayer(); }
 }
 
 std::vector<std::reference_wrapper<const Player>> GameData::getPlayersForTeam(
-    TeamID team_id) const
-{
+    TeamID team_id) const {
   std::vector<std::reference_wrapper<const Player>> players;
-  for (const auto& player : _playersVec)
-  {
-    if (player.get().getTeamId() == team_id)
-    {
-      players.push_back(player);
-    }
+  for (const auto& player : _playersVec) {
+    if (player.get().getTeamId() == team_id) { players.push_back(player); }
   }
   return players;
 }
 
-bool GameData::removePlayer(PlayerID id)
-{
+bool GameData::removePlayer(PlayerID id) {
   bool erased = _players.erase(id) > 0;
-  if (erased && !_playersVec.empty())
-  {
-    _playersVec.erase(
-        std::remove_if(_playersVec.begin(), _playersVec.end(),
-                       [id](const Player& p) { return p.getId() == id; }),
-        _playersVec.end());
+  if (erased && !_playersVec.empty()) {
+    _playersVec.erase(std::remove_if(_playersVec.begin(), _playersVec.end(),
+                                     [id](const Player& p) { return p.getId() == id; }),
+                      _playersVec.end());
   }
   return erased;
 }
 
-void from_json(const nlohmann::json& j, RoleFocus& rf)
-{
+void from_json(const nlohmann::json& j, RoleFocus& rf) {
   j.at("stats").get_to(rf.stats);
   j.at("weights").get_to(rf.weights);
 }
 
-void from_json(const nlohmann::json& j, StatsConfig& sc)
-{
+void from_json(const nlohmann::json& j, StatsConfig& sc) {
   j.at("role_focus").get_to(sc.role_focus);
   j.at("possible_stats").get_to(sc.possible_stats);
 }
 
-void GameData::loadStatsConfig()
-{
+void GameData::loadStatsConfig() {
   std::ifstream f(STATS_CONFIG_PATH);
-  if (!f.is_open())
-  {
-    throw std::runtime_error("FATAL: Could not open stats config file");
-  }
+  if (!f.is_open()) { throw std::runtime_error("FATAL: Could not open stats config file"); }
   nlohmann::json stats_config_json = nlohmann::json::parse(f);
   stats_config = stats_config_json.get<StatsConfig>();
 }

--- a/src/database/gamedata.cpp
+++ b/src/database/gamedata.cpp
@@ -17,74 +17,99 @@
 #include "global/logger.h"
 #include "global/paths.h"
 
-GameData& GameData::instance() {
+GameData& GameData::instance()
+{
   static GameData instance;
   return instance;
 }
 
-GameData::GameData() {
-  // Constructor is kept empty, initialization is done in loadFromDB
-}
+GameData::GameData() = default;
 
 // ---------------- DB ----------------
-bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr) {
+bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr)
+{
+  _leagues.clear();
+  _teams.clear();
+  _players.clear();
+  _leaguesVec.clear();
+  _teamsVec.clear();
+  _playersVec.clear();
+
   loadStatsConfig();
   db = database_ptr;
   bool is_first_run = db->isFirstRun();
 
-  Logger::debug("GameData::loadFromDB called. is_first_run: " + std::to_string(is_first_run));
+  Logger::debug("GameData::loadFromDB called. is_first_run: " +
+                std::to_string(is_first_run));
 
   std::vector<Team> all_teams;
-  if (is_first_run) {
+  if (is_first_run)
+  {
     database_ptr->initialize();
     Logger::debug("Database initialized. Generating data.");
 
     auto leagues_data = DataGenerator::generateLeagues();
     all_teams = DataGenerator::generateTeams();
 
-    for (const auto& team : all_teams) {
+    for (const auto& team : all_teams)
+    {
       database_ptr->insertTeamWithId(team);
-      _teams.emplace(team.getId(), team);
+      _teams.try_emplace(team.getId(), team);
     }
     _teamsVec.reserve(_teams.size());
     for (auto& p : _teams) _teamsVec.push_back(p.second);
 
     std::map<uint8_t, std::vector<TeamID>> league_teams_map;
-    for (const auto& team : all_teams) {
+    for (const auto& team : all_teams)
+    {
       league_teams_map[team.getLeagueId()].push_back(team.getId());
     }
 
-    for (const auto& league_data : leagues_data) {
+    for (const auto& league_data : leagues_data)
+    {
       database_ptr->insertLeagueWithId(league_data);
-      _leagues.emplace(league_data.getId(), League(league_data.getId(), league_data.getName(),
-                                                   league_teams_map[league_data.getId()]));
+      _leagues.try_emplace(league_data.getId(),
+                           League(league_data.getId(), league_data.getName(),
+                                  league_teams_map[league_data.getId()]));
     }
 
     auto players = DataGenerator::generatePlayers();
-    for (const auto& player : players) {
+    for (const auto& player : players)
+    {
       database_ptr->insertPlayer(player);
-      _players.emplace(player.getId(), player);
+      _players.try_emplace(player.getId(), player);
     }
-  } else {
+  }
+  else
+  {
     auto leagues_from_db = database_ptr->loadAllLeagues();
     all_teams = database_ptr->loadAllTeams();
 
-    for (const auto& team : all_teams) { _teams.emplace(team.getId(), team); }
+    for (const auto& team : all_teams)
+    {
+      _teams.try_emplace(team.getId(), team);
+    }
 
     std::map<uint8_t, std::vector<TeamID>> league_teams_map;
-    for (const auto& team : all_teams) {
+    for (const auto& team : all_teams)
+    {
       league_teams_map[team.getLeagueId()].push_back(team.getId());
     }
 
-    for (const auto& league_from_db : leagues_from_db) {
-      _leagues.emplace(league_from_db.getId(),
-                       League(league_from_db.getId(), league_from_db.getName(),
-                              league_teams_map[league_from_db.getId()]));
+    for (const auto& league_from_db : leagues_from_db)
+    {
+      _leagues.try_emplace(
+          league_from_db.getId(),
+          League(league_from_db.getId(), league_from_db.getName(),
+                 league_teams_map[league_from_db.getId()]));
       db->loadLeaguePoints(_leagues.at(league_from_db.getId()));
     }
 
     auto players = database_ptr->loadAllPlayers();
-    for (const auto& player : players) { _players.emplace(player.getId(), player); }
+    for (const auto& player : players)
+    {
+      _players.try_emplace(player.getId(), player);
+    }
     Logger::debug("Loaded all data from database.");
   }
 
@@ -104,111 +129,167 @@ bool GameData::loadFromDB(std::shared_ptr<Database> database_ptr) {
   return true;
 }
 
-bool GameData::saveToDB() const {
+bool GameData::saveToDB() const
+{
   if (!db) return false;
 
-  for (const auto& player_ref : _playersVec) { db->updatePlayer(player_ref.get()); }
+  for (const auto& player_ref : _playersVec)
+  {
+    db->updatePlayer(player_ref.get());
+  }
 
   return true;
 }
 
 // ---------------- League ----------------
-void GameData::addLeague(LeagueID id, const League& league) {
-  _leagues.emplace(id, league);
+void GameData::addLeague(LeagueID id, const League& league)
+{
+  _leagues.try_emplace(id, league);
   if (!_leaguesVec.empty()) _leaguesVec.push_back(_leagues.at(id));
 }
 
-std::optional<std::reference_wrapper<const League>> GameData::getLeague(LeagueID id) const {
+std::optional<std::reference_wrapper<const League>> GameData::getLeague(
+    LeagueID id) const
+{
   if (auto it = _leagues.find(id); it != _leagues.end()) return it->second;
   return std::nullopt;
 }
 
-const std::unordered_map<LeagueID, League>& GameData::getLeagues() const { return _leagues; }
+const std::unordered_map<LeagueID, League>& GameData::getLeagues() const
+{
+  return _leagues;
+}
 
-std::unordered_map<LeagueID, League>& GameData::getLeagues() { return _leagues; }
+std::unordered_map<LeagueID, League>& GameData::getLeagues()
+{
+  return _leagues;
+}
 
-const std::vector<std::reference_wrapper<const League>>& GameData::getLeaguesVector() const {
+const std::vector<std::reference_wrapper<const League>>&
+GameData::getLeaguesVector() const
+{
   return _leaguesVec;
 }
 
 // ---------------- Team ----------------
-void GameData::addTeam(TeamID id, const Team& team) {
-  _teams.emplace(id, team);
+void GameData::addTeam(TeamID id, const Team& team)
+{
+  _teams.try_emplace(id, team);
   if (!_teamsVec.empty()) _teamsVec.push_back(_teams.at(id));
 }
 
-std::optional<std::reference_wrapper<Team>> GameData::getTeam(TeamID id) {
+std::optional<std::reference_wrapper<Team>> GameData::getTeam(TeamID id)
+{
   if (auto it = _teams.find(id); it != _teams.end()) return it->second;
   return std::nullopt;
 }
 
-std::optional<std::reference_wrapper<const Team>> GameData::getTeam(TeamID id) const {
+std::optional<std::reference_wrapper<const Team>> GameData::getTeam(
+    TeamID id) const
+{
   if (auto it = _teams.find(id); it != _teams.end()) return it->second;
   return std::nullopt;
 }
 
-const std::unordered_map<TeamID, Team>& GameData::getTeams() const { return _teams; }
+const std::unordered_map<TeamID, Team>& GameData::getTeams() const
+{
+  return _teams;
+}
 
 std::unordered_map<TeamID, Team>& GameData::getTeams() { return _teams; }
 
-const std::vector<std::reference_wrapper<const Team>>& GameData::getTeamsVector() const {
+const std::vector<std::reference_wrapper<const Team>>&
+GameData::getTeamsVector() const
+{
   return _teamsVec;
 }
 
 // ---------------- Player ----------------
-void GameData::addPlayer(PlayerID id, const Player& player) {
-  _players.emplace(id, player);
-  if (!_playersVec.empty()) { _playersVec.push_back(_players.at(id)); }
+void GameData::addPlayer(PlayerID id, const Player& player)
+{
+  _players.try_emplace(id, player);
+  if (!_playersVec.empty())
+  {
+    _playersVec.push_back(_players.at(id));
+  }
 }
 
-std::optional<std::reference_wrapper<const Player>> GameData::getPlayer(PlayerID id) const {
+std::optional<std::reference_wrapper<const Player>> GameData::getPlayer(
+    PlayerID id) const
+{
   if (auto it = _players.find(id); it != _players.end()) return it->second;
   return std::nullopt;
 }
 
-const std::unordered_map<PlayerID, Player>& GameData::getPlayers() const { return _players; }
+const std::unordered_map<PlayerID, Player>& GameData::getPlayers() const
+{
+  return _players;
+}
 
-std::unordered_map<PlayerID, Player>& GameData::getPlayers() { return _players; }
-const std::vector<std::reference_wrapper<const Player>>& GameData::getPlayersVector() const {
+std::unordered_map<PlayerID, Player>& GameData::getPlayers()
+{
+  return _players;
+}
+const std::vector<std::reference_wrapper<const Player>>&
+GameData::getPlayersVector() const
+{
   return _playersVec;
 }
 
-void GameData::ageAllPlayers() {
-  for (auto& pair : _players) { pair.second.agePlayer(); }
+void GameData::ageAllPlayers()
+{
+  for (auto& pair : _players)
+  {
+    pair.second.agePlayer();
+  }
 }
 
 std::vector<std::reference_wrapper<const Player>> GameData::getPlayersForTeam(
-    TeamID team_id) const {
+    TeamID team_id) const
+{
   std::vector<std::reference_wrapper<const Player>> players;
-  for (const auto& player : _playersVec) {
-    if (player.get().getTeamId() == team_id) { players.push_back(player); }
+  for (const auto& player : _playersVec)
+  {
+    if (player.get().getTeamId() == team_id)
+    {
+      players.push_back(player);
+    }
   }
   return players;
 }
 
-bool GameData::removePlayer(PlayerID id) {
+bool GameData::removePlayer(PlayerID id)
+{
   bool erased = _players.erase(id) > 0;
-  if (erased && !_playersVec.empty()) {
-    _playersVec.erase(std::remove_if(_playersVec.begin(), _playersVec.end(),
-                                     [id](const Player& p) { return p.getId() == id; }),
-                      _playersVec.end());
+  if (erased && !_playersVec.empty())
+  {
+    _playersVec.erase(
+        std::remove_if(_playersVec.begin(), _playersVec.end(),
+                       [id](const Player& p) { return p.getId() == id; }),
+        _playersVec.end());
   }
   return erased;
 }
 
-void from_json(const nlohmann::json& j, RoleFocus& rf) {
+void from_json(const nlohmann::json& j, RoleFocus& rf)
+{
   j.at("stats").get_to(rf.stats);
   j.at("weights").get_to(rf.weights);
 }
 
-void from_json(const nlohmann::json& j, StatsConfig& sc) {
+void from_json(const nlohmann::json& j, StatsConfig& sc)
+{
   j.at("role_focus").get_to(sc.role_focus);
   j.at("possible_stats").get_to(sc.possible_stats);
 }
 
-void GameData::loadStatsConfig() {
+void GameData::loadStatsConfig()
+{
   std::ifstream f(STATS_CONFIG_PATH);
-  if (!f.is_open()) { throw std::runtime_error("FATAL: Could not open stats config file"); }
+  if (!f.is_open())
+  {
+    throw std::runtime_error("FATAL: Could not open stats config file");
+  }
   nlohmann::json stats_config_json = nlohmann::json::parse(f);
   stats_config = stats_config_json.get<StatsConfig>();
 }

--- a/src/global/language_manager.cpp
+++ b/src/global/language_manager.cpp
@@ -7,47 +7,55 @@
 // -----------------------------------------------------------------------------
 
 #include "language_manager.h"
+
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>
+
 #include "global/paths.h"
 
 using json = nlohmann::json;
 
 bool LanguageManager::loadLanguage(Language lang)
 {
-    translations.clear();
-    
-    // Map the Language enum to a filename
-    auto it = languageToString.find(lang);
-    if (it == languageToString.end()) return false;
-    
-    std::string filePath = std::string(PROJECT_ROOT) + "assets/lang/" + it->second + ".json";
-    std::ifstream file(filePath);
-    if (!file.is_open()) {
-        std::cerr << "Could not open language file: " << filePath << "\n";
-        return false;
+  translations.clear();
+
+  // Map the Language enum to a filename
+  auto it = languageToString.find(lang);
+  if (it == languageToString.end()) return false;
+
+  std::string filePath =
+      std::string(PROJECT_ROOT) + "assets/lang/" + it->second + ".json";
+  std::ifstream file(filePath);
+  if (!file.is_open())
+  {
+    std::cerr << "Could not open language file: " << filePath << "\n";
+    return false;
+  }
+
+  try
+  {
+    json j;
+    file >> j;
+    for (auto& [key, value] : j.items())
+    {
+      translations[key] = value.get<std::string>();
     }
-    
-    try {
-        json j;
-        file >> j;
-        for (auto& [key, value] : j.items()) {
-            translations[key] = value.get<std::string>();
-        }
-    } catch (const std::exception& e) {
-        std::cerr << "Error parsing language JSON: " << e.what() << "\n";
-        return false;
-    }
-    return true;
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << "Error parsing language JSON: " << e.what() << "\n";
+    return false;
+  }
+  return true;
 }
 
 const char* LanguageManager::get(const char* key) const
 {
-    if (auto it = translations.find(key);
-        it != translations.end()) 
-    {
-        return it->second.c_str();
-    }
-    return key; // Fallback to returning the literal key pointer if translation is missing
+  if (auto it = translations.find(key); it != translations.end())
+  {
+    return it->second.c_str();
+  }
+  return key;  // Fallback to returning the literal key pointer if translation
+               // is missing
 }

--- a/src/global/language_manager.h
+++ b/src/global/language_manager.h
@@ -11,12 +11,14 @@
 
 #include <string>
 #include <unordered_map>
+
 #include "global/languages.h"
 
 class LanguageManager
 {
  public:
-  static LanguageManager& instance() {
+  static LanguageManager& instance()
+  {
     static LanguageManager instance;
     return instance;
   }
@@ -35,4 +37,4 @@ class LanguageManager
 // Global helper macro for concise UI code
 #define LOC(key) LanguageManager::instance().get(key)
 
-#endif // LANGUAGE_MANAGER_H
+#endif  // LANGUAGE_MANAGER_H

--- a/src/gui/gui_constants.h
+++ b/src/gui/gui_constants.h
@@ -10,7 +10,8 @@
 
 #include <array>
 
-namespace GUIConstants {
+namespace GUIConstants
+{
 
 // Button sizes
 constexpr float BUTTON_WIDTH = 120.0f;
@@ -23,13 +24,15 @@ constexpr float MENU_BUTTON_HEIGHT = 50.0f;
 // Window layout
 constexpr float CENTER_PIVOT = 0.5f;
 
-struct Resolution {
+struct Resolution
+{
   int width;
   int height;
 };
 
 constexpr std::array<int, 4> FPS_OPTIONS = {60, 90, 120, 144};
-constexpr std::array<Resolution, 4> RESOLUTIONS = {Resolution{1280, 720}, Resolution{1920, 1080},
-                                                   Resolution{2560, 1440}, Resolution{3840, 2160}};
+constexpr std::array<Resolution, 4> RESOLUTIONS = {
+    Resolution{1280, 720}, Resolution{1920, 1080}, Resolution{2560, 1440},
+    Resolution{3840, 2160}};
 
 }  // namespace GUIConstants

--- a/src/gui/gui_view.cpp
+++ b/src/gui/gui_view.cpp
@@ -7,15 +7,16 @@
 // -----------------------------------------------------------------------------
 
 #include "gui/gui_view.h"
-#include "global/paths.h"
+
+#include <SDL3_ttf/SDL_ttf.h>
 
 #include <iostream>
 #include <stack>
 
 #include "backends/imgui_impl_sdl3.h"
 #include "backends/imgui_impl_sdlrenderer3.h"
-#include <SDL3_ttf/SDL_ttf.h>
 #include "controller/game_controller.h"
+#include "global/paths.h"
 #include "gui/gui_scene.h"
 #include "gui/scenes/main_menu_scene.h"
 #include "gui/scenes/team_selection_scene.h"
@@ -102,9 +103,10 @@ bool GUIView::initialize()
 
   // Load high quality TTF font to replace the pixelated default
   std::string fontPath = std::string(PROJECT_ROOT) + "assets/fonts/font.ttf";
-  if (io.Fonts->AddFontFromFileTTF(fontPath.c_str(), 20.0f) == nullptr) {
-      std::cerr << "Failed to load font: " << fontPath << '\n';
-      return false;
+  if (io.Fonts->AddFontFromFileTTF(fontPath.c_str(), 20.0f) == nullptr)
+  {
+    std::cerr << "Failed to load font: " << fontPath << '\n';
+    return false;
   }
 
   ImGui_ImplSDL3_InitForSDLRenderer(window, renderer);
@@ -225,10 +227,7 @@ void GUIView::overlayScene(std::unique_ptr<GUIScene> overlay)
   pendingScene = std::move(overlay);
 }
 
-void GUIView::popScene()
-{
-  pendingAction = PendingAction::POP;
-}
+void GUIView::popScene() { pendingAction = PendingAction::POP; }
 
 void GUIView::applyPendingSceneChanges()
 {

--- a/src/gui/gui_view.h
+++ b/src/gui/gui_view.h
@@ -80,7 +80,13 @@ class GUIView
   std::stack<std::unique_ptr<GUIScene>> sceneStack;
 
   // Deferred scene management
-  enum class PendingAction { NONE, CHANGE, OVERLAY, POP };
+  enum class PendingAction
+  {
+    NONE,
+    CHANGE,
+    OVERLAY,
+    POP
+  };
   PendingAction pendingAction = PendingAction::NONE;
   std::unique_ptr<GUIScene> pendingScene;
   void applyPendingSceneChanges();

--- a/src/gui/scenes/main_game_scene.cpp
+++ b/src/gui/scenes/main_game_scene.cpp
@@ -7,8 +7,11 @@
 // -----------------------------------------------------------------------------
 
 #include "main_game_scene.h"
+
 #include <imgui.h>
+
 #include <algorithm>
+
 #include "global/language_manager.h"
 #include "gui/gui_constants.h"
 #include "gui/gui_view.h"
@@ -77,7 +80,8 @@ void MainGameScene::renderTopBar()
   std::string dateStr = guiView->getController().getCurrentDate().toString();
   ImGui::Text(LOC("MAIN_GAME_DATE"), dateStr.c_str());
   ImGui::SameLine(ImGui::GetWindowWidth() - NEXT_DAY_BUTTON_OFFSET);
-  if (ImGui::Button(LOC("MAIN_GAME_NEXT_DAY"), ImVec2(NEXT_DAY_BUTTON_WIDTH, NEXT_DAY_BUTTON_HEIGHT)))
+  if (ImGui::Button(LOC("MAIN_GAME_NEXT_DAY"),
+                    ImVec2(NEXT_DAY_BUTTON_WIDTH, NEXT_DAY_BUTTON_HEIGHT)))
   {
     guiView->getController().advanceDay();
   }
@@ -86,26 +90,36 @@ void MainGameScene::renderTopBar()
 void MainGameScene::renderSidebar()
 {
   ImGui::BeginChild("Sidebar", ImVec2(0, 0), true);
-  if (ImGui::Button(LOC("MAIN_GAME_VIEW_ROSTER"), ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
+  if (ImGui::Button(LOC("MAIN_GAME_VIEW_ROSTER"),
+                    ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
   {
     guiView->overlayScene(std::make_unique<RosterScene>(guiView));
   }
   ImGui::Spacing();
-  if (ImGui::Button(LOC("MAIN_GAME_SET_STRATEGY"), ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
+  if (ImGui::Button(LOC("MAIN_GAME_SET_STRATEGY"),
+                    ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
   {
     guiView->overlayScene(std::make_unique<StrategyScene>(guiView));
   }
   ImGui::Spacing();
-  if (ImGui::Button(LOC("MAIN_GAME_FINANCES"), ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT))) {}
+  if (ImGui::Button(LOC("MAIN_GAME_FINANCES"),
+                    ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
+  {
+  }
   ImGui::Spacing();
-  if (ImGui::Button(LOC("MAIN_GAME_TRANSFER_MARKET"), ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT))) {}
+  if (ImGui::Button(LOC("MAIN_GAME_TRANSFER_MARKET"),
+                    ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
+  {
+  }
   ImGui::Spacing();
-  if (ImGui::Button(LOC("MAIN_GAME_SAVE_GAME"), ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
+  if (ImGui::Button(LOC("MAIN_GAME_SAVE_GAME"),
+                    ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
   {
     guiView->getController().saveGame();
   }
   ImGui::Spacing();
-  if (ImGui::Button(LOC("MAIN_GAME_MAIN_MENU"), ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
+  if (ImGui::Button(LOC("MAIN_GAME_MAIN_MENU"),
+                    ImVec2(-FLT_MIN, SIDEBAR_BUTTON_HEIGHT)))
   {
     changeScene(std::make_unique<MainMenuScene>(guiView));
   }
@@ -124,26 +138,35 @@ void MainGameScene::renderMainArea()
   auto managedTeamOpt = guiView->getController().getManagedTeam();
   if (managedTeamOpt.has_value())
   {
-    auto leagueOpt = guiView->getController().getLeagueById(managedTeamOpt->get().getLeagueId());
+    auto leagueOpt = guiView->getController().getLeagueById(
+        managedTeamOpt->get().getLeagueId());
     if (leagueOpt.has_value())
     {
       const League& league = leagueOpt->get();
       const auto& leaderboard = league.getLeaderboard();
-      std::vector<std::pair<int, int>> sorted_teams(leaderboard.begin(), leaderboard.end());
+      std::vector<std::pair<int, int>> sorted_teams(leaderboard.begin(),
+                                                    leaderboard.end());
       std::sort(sorted_teams.begin(), sorted_teams.end(),
-                [](const auto& a, const auto& b) { return a.second > b.second; });
+                [](const auto& a, const auto& b)
+                { return a.second > b.second; });
 
-      if (ImGui::BeginTable("Standings", STANDINGS_COLUMNS, ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders))
+      if (ImGui::BeginTable("Standings", STANDINGS_COLUMNS,
+                            ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders))
       {
-        ImGui::TableSetupColumn(LOC("MAIN_GAME_POS"), ImGuiTableColumnFlags_WidthFixed, POS_COL_WIDTH);
+        ImGui::TableSetupColumn(LOC("MAIN_GAME_POS"),
+                                ImGuiTableColumnFlags_WidthFixed,
+                                POS_COL_WIDTH);
         ImGui::TableSetupColumn(LOC("MAIN_GAME_TEAM"));
-        ImGui::TableSetupColumn(LOC("MAIN_GAME_PTS"), ImGuiTableColumnFlags_WidthFixed, PTS_COL_WIDTH);
+        ImGui::TableSetupColumn(LOC("MAIN_GAME_PTS"),
+                                ImGuiTableColumnFlags_WidthFixed,
+                                PTS_COL_WIDTH);
         ImGui::TableHeadersRow();
 
         int rank = 1;
         for (const auto& pair : sorted_teams)
         {
-          auto teamOpt = guiView->getController().getTeamById(static_cast<uint16_t>(pair.first));
+          auto teamOpt = guiView->getController().getTeamById(
+              static_cast<uint16_t>(pair.first));
           if (teamOpt.has_value())
           {
             ImGui::TableNextRow();
@@ -168,18 +191,24 @@ void MainGameScene::renderMainArea()
   ImGui::Separator();
   if (managedTeamOpt.has_value())
   {
-    auto players = guiView->getController().getPlayersForTeam(managedTeamOpt->get().getId());
+    auto players = guiView->getController().getPlayersForTeam(
+        managedTeamOpt->get().getId());
     const auto& stats_config = guiView->getController().getStatsConfig();
     std::sort(players.begin(), players.end(),
               [&stats_config](const std::reference_wrapper<const Player>& a,
                               const std::reference_wrapper<const Player>& b)
-              { return a.get().getOverall(stats_config) > b.get().getOverall(stats_config); });
+              {
+                return a.get().getOverall(stats_config) >
+                       b.get().getOverall(stats_config);
+              });
 
-    if (ImGui::BeginTable("TopPlayers", TOP_PLAYERS_COLUMNS, ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders))
+    if (ImGui::BeginTable("TopPlayers", TOP_PLAYERS_COLUMNS,
+                          ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders))
     {
       ImGui::TableSetupColumn(LOC("MAIN_GAME_NAME"));
       ImGui::TableSetupColumn(LOC("MAIN_GAME_ROLE"));
-      ImGui::TableSetupColumn(LOC("MAIN_GAME_OVR"), ImGuiTableColumnFlags_WidthFixed, OVR_COL_WIDTH);
+      ImGui::TableSetupColumn(LOC("MAIN_GAME_OVR"),
+                              ImGuiTableColumnFlags_WidthFixed, OVR_COL_WIDTH);
       ImGui::TableHeadersRow();
 
       for (size_t i = 0; i < MAX_TOP_PLAYERS && i < players.size(); ++i)

--- a/src/gui/scenes/main_menu_scene.cpp
+++ b/src/gui/scenes/main_menu_scene.cpp
@@ -23,38 +23,47 @@ MainMenuScene::MainMenuScene(GUIView* guiView_ptr) : GUIScene(guiView_ptr) {}
 
 void MainMenuScene::update(float deltaTime) { (void)deltaTime; }
 
-void MainMenuScene::render() {
-  ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always,
-                          ImVec2(0.5f, 0.5f));
-  ImGui::Begin("Football Management", nullptr,
-               ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize);
+void MainMenuScene::render()
+{
+  ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(),
+                          ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+  ImGui::Begin(
+      "Football Management", nullptr,
+      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize);
 
   ImGui::Text("%s", LOC("MENU_TITLE"));
   ImGui::Separator();
   ImGui::Spacing();
 
   if (ImGui::Button(LOC("MENU_NEW_GAME"),
-                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH, GUIConstants::MENU_BUTTON_HEIGHT))) {
+                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH,
+                           GUIConstants::MENU_BUTTON_HEIGHT)))
+  {
     auto gameScene = std::make_unique<MainGameScene>(guiView);
     changeScene(std::move(gameScene));
   }
   ImGui::Spacing();
 
   if (ImGui::Button(LOC("MENU_LOAD_GAME"),
-                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH, GUIConstants::MENU_BUTTON_HEIGHT))) {
+                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH,
+                           GUIConstants::MENU_BUTTON_HEIGHT)))
+  {
     // TODO load game logic
   }
   ImGui::Spacing();
 
   if (ImGui::Button(LOC("MENU_SETTINGS"),
-                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH, GUIConstants::MENU_BUTTON_HEIGHT))) {
+                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH,
+                           GUIConstants::MENU_BUTTON_HEIGHT)))
+  {
     auto settingsScene = std::make_unique<SettingsScene>(guiView);
     changeScene(std::move(settingsScene));
   }
   ImGui::Spacing();
 
-  if (ImGui::Button(LOC("MENU_QUIT"),
-                    ImVec2(GUIConstants::MENU_BUTTON_WIDTH, GUIConstants::MENU_BUTTON_HEIGHT))) {
+  if (ImGui::Button(LOC("MENU_QUIT"), ImVec2(GUIConstants::MENU_BUTTON_WIDTH,
+                                             GUIConstants::MENU_BUTTON_HEIGHT)))
+  {
     quit();
   }
 

--- a/src/gui/scenes/roster_scene.cpp
+++ b/src/gui/scenes/roster_scene.cpp
@@ -7,7 +7,9 @@
 // -----------------------------------------------------------------------------
 
 #include "roster_scene.h"
+
 #include <imgui.h>
+
 #include "global/language_manager.h"
 #include "gui/gui_constants.h"
 #include "gui/gui_view.h"
@@ -22,37 +24,49 @@ constexpr float OVERALL_COLUMN_WIDTH = 60.0f;
 
 RosterScene::RosterScene(GUIView* parent) : GUIScene(parent) {}
 
-void RosterScene::onEnter()
-{
-  loadRoster();
-}
+void RosterScene::onEnter() { loadRoster(); }
 
 void RosterScene::update(float deltaTime) { (void)deltaTime; }
 
 void RosterScene::render()
 {
-  ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(GUIConstants::CENTER_PIVOT, GUIConstants::CENTER_PIVOT));
-  ImGui::SetNextWindowSize(ImVec2(WINDOW_WIDTH, WINDOW_HEIGHT), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowPos(
+      ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always,
+      ImVec2(GUIConstants::CENTER_PIVOT, GUIConstants::CENTER_PIVOT));
+  ImGui::SetNextWindowSize(ImVec2(WINDOW_WIDTH, WINDOW_HEIGHT),
+                           ImGuiCond_FirstUseEver);
   ImGui::Begin(LOC("ROSTER_TITLE"), nullptr, ImGuiWindowFlags_NoCollapse);
 
-  if (ImGui::Button(LOC("ROSTER_BACK"), ImVec2(GUIConstants::BUTTON_WIDTH, GUIConstants::BUTTON_HEIGHT))) {
+  if (ImGui::Button(LOC("ROSTER_BACK"), ImVec2(GUIConstants::BUTTON_WIDTH,
+                                               GUIConstants::BUTTON_HEIGHT)))
+  {
     guiView->popScene();
   }
   ImGui::Separator();
   ImGui::Spacing();
 
-  if (ImGui::BeginTable("RosterTable", TABLE_COLUMNS, ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable)) {
+  if (ImGui::BeginTable("RosterTable", TABLE_COLUMNS,
+                        ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders |
+                            ImGuiTableFlags_Resizable))
+  {
     ImGui::TableSetupColumn(LOC("ROSTER_COL_NAME"));
     ImGui::TableSetupColumn(LOC("ROSTER_COL_ROLE"));
-    ImGui::TableSetupColumn(LOC("ROSTER_COL_OVERALL"), ImGuiTableColumnFlags_WidthFixed, OVERALL_COLUMN_WIDTH);
+    ImGui::TableSetupColumn(LOC("ROSTER_COL_OVERALL"),
+                            ImGuiTableColumnFlags_WidthFixed,
+                            OVERALL_COLUMN_WIDTH);
     ImGui::TableHeadersRow();
 
-    for (const auto& player_ref : roster_players) {
+    for (const auto& player_ref : roster_players)
+    {
       const Player& player = player_ref.get();
       ImGui::TableNextRow();
-      ImGui::TableNextColumn(); ImGui::Text("%s", player.getName().c_str());
-      ImGui::TableNextColumn(); ImGui::Text("%s", player.getRole().c_str());
-      ImGui::TableNextColumn(); ImGui::Text("%.1f", player.getOverall(guiView->getController().getStatsConfig()));
+      ImGui::TableNextColumn();
+      ImGui::Text("%s", player.getName().c_str());
+      ImGui::TableNextColumn();
+      ImGui::Text("%s", player.getRole().c_str());
+      ImGui::TableNextColumn();
+      ImGui::Text("%.1f",
+                  player.getOverall(guiView->getController().getStatsConfig()));
     }
     ImGui::EndTable();
   }
@@ -63,8 +77,10 @@ void RosterScene::render()
 void RosterScene::loadRoster()
 {
   auto managedTeamOpt = guiView->getController().getManagedTeam();
-  if (managedTeamOpt.has_value()) {
-    roster_players = guiView->getController().getPlayersForTeam(managedTeamOpt->get().getId());
+  if (managedTeamOpt.has_value())
+  {
+    roster_players = guiView->getController().getPlayersForTeam(
+        managedTeamOpt->get().getId());
   }
 }
 

--- a/src/gui/scenes/roster_scene.h
+++ b/src/gui/scenes/roster_scene.h
@@ -7,9 +7,10 @@
 // -----------------------------------------------------------------------------
 
 #pragma once
+#include <vector>
+
 #include "gui/gui_scene.h"
 #include "model/player.h"
-#include <vector>
 
 class RosterScene : public GUIScene
 {

--- a/src/gui/scenes/settings_scene.cpp
+++ b/src/gui/scenes/settings_scene.cpp
@@ -11,10 +11,10 @@
 #include <imgui.h>
 
 #include <algorithm>
-
-#include "global/paths.h"
-#include "global/language_manager.h"
 #include <filesystem>
+
+#include "global/language_manager.h"
+#include "global/paths.h"
 #include "gui/gui_constants.h"
 #include "gui/scenes/main_menu_scene.h"
 #include "settings_manager.h"
@@ -29,7 +29,8 @@ void SettingsScene::onEnter()
   availableLanguageEnums.clear();
   for (const auto& [lang, str] : languageToString)
   {
-    std::string filePath = std::string(PROJECT_ROOT) + "assets/lang/" + str + ".json";
+    std::string filePath =
+        std::string(PROJECT_ROOT) + "assets/lang/" + str + ".json";
     if (std::filesystem::exists(filePath))
     {
       languageOptions.push_back(str);
@@ -92,7 +93,8 @@ void SettingsScene::render()
   ImGui::Separator();
   ImGui::Spacing();
 
-  if (ImGui::BeginCombo(LOC("SETTINGS_LANGUAGE"), languageOptions[selectedLanguage].c_str()))
+  if (ImGui::BeginCombo(LOC("SETTINGS_LANGUAGE"),
+                        languageOptions[selectedLanguage].c_str()))
   {
     for (size_t i = 0; i < languageOptions.size(); i++)
     {
@@ -117,7 +119,8 @@ void SettingsScene::render()
     ImGui::EndCombo();
   }
 
-  if (ImGui::BeginCombo(LOC("SETTINGS_REFRESH_RATE"), fpsOptionsStrings[selectedFPS].c_str()))
+  if (ImGui::BeginCombo(LOC("SETTINGS_REFRESH_RATE"),
+                        fpsOptionsStrings[selectedFPS].c_str()))
   {
     for (size_t i = 0; i < fpsOptionsStrings.size(); i++)
     {
@@ -135,14 +138,15 @@ void SettingsScene::render()
   ImGui::Separator();
   ImGui::Spacing();
 
-  if (ImGui::Button(LOC("SETTINGS_CANCEL"), ImVec2(GUIConstants::BUTTON_WIDTH,
-                                     GUIConstants::BUTTON_HEIGHT)))
+  if (ImGui::Button(
+          LOC("SETTINGS_CANCEL"),
+          ImVec2(GUIConstants::BUTTON_WIDTH, GUIConstants::BUTTON_HEIGHT)))
   {
     changeScene(std::make_unique<MainMenuScene>(guiView));
   }
   ImGui::SameLine();
   if (ImGui::Button(LOC("SETTINGS_APPLY"), ImVec2(GUIConstants::BUTTON_WIDTH,
-                                     GUIConstants::BUTTON_HEIGHT)))
+                                                  GUIConstants::BUTTON_HEIGHT)))
   {
     applyAndSaveSettings();
   }

--- a/src/gui/scenes/strategy_scene.cpp
+++ b/src/gui/scenes/strategy_scene.cpp
@@ -7,7 +7,9 @@
 // -----------------------------------------------------------------------------
 
 #include "strategy_scene.h"
+
 #include <imgui.h>
+
 #include "global/language_manager.h"
 #include "gui/gui_constants.h"
 #include "gui/gui_view.h"
@@ -20,34 +22,43 @@ constexpr float WINDOW_HEIGHT = 400.0f;
 
 StrategyScene::StrategyScene(GUIView* parent) : GUIScene(parent) {}
 
-void StrategyScene::onEnter()
-{
-  loadStrategy();
-}
+void StrategyScene::onEnter() { loadStrategy(); }
 
 void StrategyScene::update(float deltaTime) { (void)deltaTime; }
 
 void StrategyScene::render()
 {
-  ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(GUIConstants::CENTER_PIVOT, GUIConstants::CENTER_PIVOT));
-  ImGui::SetNextWindowSize(ImVec2(WINDOW_WIDTH, WINDOW_HEIGHT), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowPos(
+      ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always,
+      ImVec2(GUIConstants::CENTER_PIVOT, GUIConstants::CENTER_PIVOT));
+  ImGui::SetNextWindowSize(ImVec2(WINDOW_WIDTH, WINDOW_HEIGHT),
+                           ImGuiCond_FirstUseEver);
   ImGui::Begin(LOC("STRATEGY_TITLE"), nullptr, ImGuiWindowFlags_NoCollapse);
 
-  ImGui::SliderFloat(LOC("STRATEGY_PRESSING"), &current_sliders.pressing, 0.0f, 1.0f);
-  ImGui::SliderFloat(LOC("STRATEGY_RISK_TAKING"), &current_sliders.riskTaking, 0.0f, 1.0f);
-  ImGui::SliderFloat(LOC("STRATEGY_OFFENSIVE_BIAS"), &current_sliders.offensiveBias, 0.0f, 1.0f);
-  ImGui::SliderFloat(LOC("STRATEGY_WIDTH_USAGE"), &current_sliders.widthUsage, 0.0f, 1.0f);
-  ImGui::SliderFloat(LOC("STRATEGY_COMPACTNESS"), &current_sliders.compactness, 0.0f, 1.0f);
+  ImGui::SliderFloat(LOC("STRATEGY_PRESSING"), &current_sliders.pressing, 0.0f,
+                     1.0f);
+  ImGui::SliderFloat(LOC("STRATEGY_RISK_TAKING"), &current_sliders.riskTaking,
+                     0.0f, 1.0f);
+  ImGui::SliderFloat(LOC("STRATEGY_OFFENSIVE_BIAS"),
+                     &current_sliders.offensiveBias, 0.0f, 1.0f);
+  ImGui::SliderFloat(LOC("STRATEGY_WIDTH_USAGE"), &current_sliders.widthUsage,
+                     0.0f, 1.0f);
+  ImGui::SliderFloat(LOC("STRATEGY_COMPACTNESS"), &current_sliders.compactness,
+                     0.0f, 1.0f);
 
   ImGui::Spacing();
   ImGui::Separator();
   ImGui::Spacing();
 
-  if (ImGui::Button(LOC("STRATEGY_BACK"), ImVec2(GUIConstants::BUTTON_WIDTH, GUIConstants::BUTTON_HEIGHT))) {
+  if (ImGui::Button(LOC("STRATEGY_BACK"), ImVec2(GUIConstants::BUTTON_WIDTH,
+                                                 GUIConstants::BUTTON_HEIGHT)))
+  {
     guiView->popScene();
   }
   ImGui::SameLine();
-  if (ImGui::Button(LOC("STRATEGY_APPLY"), ImVec2(GUIConstants::BUTTON_WIDTH, GUIConstants::BUTTON_HEIGHT))) {
+  if (ImGui::Button(LOC("STRATEGY_APPLY"), ImVec2(GUIConstants::BUTTON_WIDTH,
+                                                  GUIConstants::BUTTON_HEIGHT)))
+  {
     saveStrategy();
     guiView->popScene();
   }
@@ -58,7 +69,8 @@ void StrategyScene::render()
 void StrategyScene::saveStrategy()
 {
   auto managedTeamOpt = guiView->getController().getManagedTeam();
-  if (managedTeamOpt.has_value()) {
+  if (managedTeamOpt.has_value())
+  {
     managedTeamOpt->get().getStrategy().setAllSliders(current_sliders);
     guiView->getController().saveGame();
   }
@@ -67,7 +79,8 @@ void StrategyScene::saveStrategy()
 void StrategyScene::loadStrategy()
 {
   auto managedTeamOpt = guiView->getController().getManagedTeam();
-  if (managedTeamOpt.has_value()) {
+  if (managedTeamOpt.has_value())
+  {
     current_sliders = managedTeamOpt->get().getStrategy().getSliders();
   }
 }

--- a/src/gui/scenes/team_selection_scene.cpp
+++ b/src/gui/scenes/team_selection_scene.cpp
@@ -16,7 +16,8 @@
 #include "gui/gui_constants.h"
 #include "gui/gui_view.h"
 
-namespace {
+namespace
+{
 constexpr float WINDOW_WIDTH = 800.0f;
 constexpr float WINDOW_HEIGHT = 600.0f;
 constexpr float LEAGUES_REGION_HEIGHT = 100.0f;
@@ -29,24 +30,33 @@ void TeamSelectionScene::onEnter() { loadAvailableLeagues(); }
 
 void TeamSelectionScene::update(float deltaTime) { (void)deltaTime; }
 
-void TeamSelectionScene::render() {
-  ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always,
-                          ImVec2(GUIConstants::CENTER_PIVOT, GUIConstants::CENTER_PIVOT));
-  ImGui::SetNextWindowSize(ImVec2(WINDOW_WIDTH, WINDOW_HEIGHT), ImGuiCond_FirstUseEver);
-  ImGui::Begin(LOC("TEAM_SELECTION_TITLE"), nullptr, ImGuiWindowFlags_NoCollapse);
+void TeamSelectionScene::render()
+{
+  ImGui::SetNextWindowPos(
+      ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always,
+      ImVec2(GUIConstants::CENTER_PIVOT, GUIConstants::CENTER_PIVOT));
+  ImGui::SetNextWindowSize(ImVec2(WINDOW_WIDTH, WINDOW_HEIGHT),
+                           ImGuiCond_FirstUseEver);
+  ImGui::Begin(LOC("TEAM_SELECTION_TITLE"), nullptr,
+               ImGuiWindowFlags_NoCollapse);
 
   ImGui::Text("%s", LOC("TEAM_SELECTION_LEAGUES"));
   ImGui::Separator();
 
   ImGui::BeginChild("LeaguesRegion", ImVec2(0, LEAGUES_REGION_HEIGHT), true,
                     ImGuiWindowFlags_HorizontalScrollbar);
-  for (const auto& league_ref : available_leagues) {
+  for (const auto& league_ref : available_leagues)
+  {
     const League& league = league_ref.get();
-    bool is_selected = (selected_league_id && selected_league_id.value() == league.getId());
-    if (is_selected) ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.2f, 0.6f, 0.2f, 1.0f));
+    bool is_selected =
+        (selected_league_id && selected_league_id.value() == league.getId());
+    if (is_selected)
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.2f, 0.6f, 0.2f, 1.0f));
 
     if (ImGui::Button(league.getName().c_str(),
-                      ImVec2(GUIConstants::MENU_BUTTON_WIDTH, GUIConstants::MENU_BUTTON_HEIGHT))) {
+                      ImVec2(GUIConstants::MENU_BUTTON_WIDTH,
+                             GUIConstants::MENU_BUTTON_HEIGHT)))
+    {
       selected_league_id = league.getId();
       loadAvailableTeams();
     }
@@ -60,15 +70,19 @@ void TeamSelectionScene::render() {
   ImGui::Text("%s", LOC("TEAM_SELECTION_TEAMS"));
   ImGui::Separator();
 
-  if (selected_league_id) {
+  if (selected_league_id)
+  {
     ImGui::BeginChild("TeamsRegion", ImVec2(0, 0), true);
 
-    if (ImGui::BeginTable("TeamsTable", TEAM_COLUMNS)) {
-      for (size_t i = 0; i < available_teams.size(); i++) {
+    if (ImGui::BeginTable("TeamsTable", TEAM_COLUMNS))
+    {
+      for (size_t i = 0; i < available_teams.size(); i++)
+      {
         ImGui::TableNextColumn();
         const Team& team = available_teams[i].get();
         if (ImGui::Button(team.getName().c_str(),
-                          ImVec2(-FLT_MIN, GUIConstants::MENU_BUTTON_HEIGHT))) {
+                          ImVec2(-FLT_MIN, GUIConstants::MENU_BUTTON_HEIGHT)))
+        {
           guiView->getController().selectManagedTeam(team.getId());
           guiView->popScene();  // Assumes TeamSelection is overlay
         }
@@ -76,25 +90,31 @@ void TeamSelectionScene::render() {
       ImGui::EndTable();
     }
     ImGui::EndChild();
-  } else {
+  }
+  else
+  {
     ImGui::Text("%s", LOC("TEAM_SELECTION_SELECT_LEAGUE_FIRST"));
   }
 
   ImGui::End();
 }
 
-void TeamSelectionScene::loadAvailableLeagues() {
+void TeamSelectionScene::loadAvailableLeagues()
+{
   available_leagues = guiView->getController().getLeagues();
 }
 
-void TeamSelectionScene::loadAvailableTeams() {
+void TeamSelectionScene::loadAvailableTeams()
+{
   if (!selected_league_id) return;
   auto all_teams = guiView->getController().getTeams();
   available_teams.clear();
-  for (const auto& team_ref : all_teams) {
+  for (const auto& team_ref : all_teams)
+  {
     const Team& team = team_ref.get();
     if (team.getLeagueId() == selected_league_id.value() &&
-        team.getName() != FREE_AGENTS_TEAM_NAME) {
+        team.getName() != FREE_AGENTS_TEAM_NAME)
+    {
       available_teams.push_back(team_ref);
     }
   }

--- a/src/gui/scenes/team_selection_scene.h
+++ b/src/gui/scenes/team_selection_scene.h
@@ -15,7 +15,8 @@
 #include "model/league.h"
 #include "model/team.h"
 
-class TeamSelectionScene : public GUIScene {
+class TeamSelectionScene : public GUIScene
+{
  public:
   explicit TeamSelectionScene(GUIView* parent);
   ~TeamSelectionScene() override = default;

--- a/src/model/settings_manager.cpp
+++ b/src/model/settings_manager.cpp
@@ -12,8 +12,8 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
-#include "global/paths.h"
 #include "global/language_manager.h"
+#include "global/paths.h"
 
 using json = nlohmann::json;
 

--- a/test/test_game_flow.cpp
+++ b/test/test_game_flow.cpp
@@ -6,116 +6,123 @@
 //  See the LICENSE file in the project root.
 // -----------------------------------------------------------------------------
 
+#include <SDL3/SDL.h>
 #include <gtest/gtest.h>
+
 #include <memory>
 #include <string>
 
 #include "controller/game_controller.h"
 #include "global/logger.h"
-#include "model/game.h"
-#include "model/team.h"
-#include "model/player.h"
 #include "gui/gui_view.h"
-#include "gui/scenes/main_menu_scene.h"
-#include "gui/scenes/settings_scene.h"
 #include "gui/scenes/main_game_scene.h"
+#include "gui/scenes/main_menu_scene.h"
 #include "gui/scenes/roster_scene.h"
+#include "gui/scenes/settings_scene.h"
 #include "gui/scenes/strategy_scene.h"
 #include "gui/scenes/team_selection_scene.h"
-#include <SDL3/SDL.h>
+#include "model/game.h"
+#include "model/player.h"
+#include "model/team.h"
 
-class GameFlowTest : public ::testing::Test {
-protected:
-    void SetUp() override {
-        // Initialize Logger to prevent segfaults when Game or Database try to log
-        Logger::init();
-        
-        game = std::make_unique<Game>();
-        controller = std::make_unique<GameController>(std::move(game));
-    }
+class GameFlowTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    // Initialize Logger to prevent segfaults when Game or Database try to log
+    Logger::init();
 
-    std::unique_ptr<Game> game;
-    std::unique_ptr<GameController> controller;
+    game = std::make_unique<Game>();
+    controller = std::make_unique<GameController>(std::move(game));
+  }
+
+  std::unique_ptr<Game> game;
+  std::unique_ptr<GameController> controller;
 };
 
-TEST_F(GameFlowTest, FullLifecycle) {
-    // 1. Start a New Game
-    // We assume there's a valid team ID, e.g., team ID 1.
-    // Normally we'd fetch an actual team from the game's team list.
-    auto teams = controller->getTeams();
-    ASSERT_FALSE(teams.empty()) << "No teams loaded in the database!";
-    
-    TeamID firstTeamId = teams.front().get().getId();
-    EXPECT_NO_THROW(controller->selectManagedTeam(firstTeamId));
+TEST_F(GameFlowTest, FullLifecycle)
+{
+  // 1. Start a New Game
+  // We assume there's a valid team ID, e.g., team ID 1.
+  // Normally we'd fetch an actual team from the game's team list.
+  auto teams = controller->getTeams();
+  ASSERT_FALSE(teams.empty()) << "No teams loaded in the database!";
 
-    // 2. Data Access Check
-    auto userTeamOpt = controller->getManagedTeam();
-    ASSERT_TRUE(userTeamOpt.has_value()) << "User team should be assigned after selectManagedTeam";
-    
-    auto roster = controller->getPlayersForTeam(userTeamOpt->get().getId());
-    EXPECT_GT(roster.size(), 0) << "User team should have players in the roster";
+  TeamID firstTeamId = teams.front().get().getId();
+  EXPECT_NO_THROW(controller->selectManagedTeam(firstTeamId));
 
-    // 3. Time Advancement
-    // Simulate advancing a few days
-    EXPECT_NO_THROW({
-        controller->advanceDay();
-        controller->advanceDay();
-    });
+  // 2. Data Access Check
+  auto userTeamOpt = controller->getManagedTeam();
+  ASSERT_TRUE(userTeamOpt.has_value())
+      << "User team should be assigned after selectManagedTeam";
 
-    // 4. Persistence Check
-    EXPECT_NO_THROW({
-        controller->saveGame();
-    }) << "saveGame() should not throw or core dump";
+  auto roster = controller->getPlayersForTeam(userTeamOpt->get().getId());
+  EXPECT_GT(roster.size(), 0) << "User team should have players in the roster";
 
-    // We can verify that the controller survives saving without invalidating state
-    EXPECT_EQ(controller->getManagedTeam()->get().getId(), firstTeamId);
+  // 3. Time Advancement
+  // Simulate advancing a few days
+  EXPECT_NO_THROW({
+    controller->advanceDay();
+    controller->advanceDay();
+  });
+
+  // 4. Persistence Check
+  EXPECT_NO_THROW({ controller->saveGame(); })
+      << "saveGame() should not throw or core dump";
+
+  // We can verify that the controller survives saving without invalidating
+  // state
+  EXPECT_EQ(controller->getManagedTeam()->get().getId(), firstTeamId);
 }
 
-TEST_F(GameFlowTest, GUIFlowLifecycle) {
-    // Enable headless SDL for testing
-    SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "dummy");
-    
-    GUIView view(*controller);
-    EXPECT_TRUE(view.initialize());
+TEST_F(GameFlowTest, GUIFlowLifecycle)
+{
+  // Enable headless SDL for testing
+  SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "dummy");
 
-    auto step_frame = [&view]() {
-        view.handleEvents();
-        view.update(0.16f);
-        view.render();
-    };
+  GUIView view(*controller);
+  EXPECT_TRUE(view.initialize());
 
-    // 1. Initial frame (Main Menu)
-    EXPECT_NO_THROW(step_frame());
+  auto step_frame = [&view]()
+  {
+    view.handleEvents();
+    view.update(0.16f);
+    view.render();
+  };
 
-    // 2. Change to Settings
-    view.changeScene(std::make_unique<SettingsScene>(&view));
-    EXPECT_NO_THROW(step_frame());
+  // 1. Initial frame (Main Menu)
+  EXPECT_NO_THROW(step_frame());
 
-    // 3. Change back to Main Menu
-    view.changeScene(std::make_unique<MainMenuScene>(&view));
-    EXPECT_NO_THROW(step_frame());
+  // 2. Change to Settings
+  view.changeScene(std::make_unique<SettingsScene>(&view));
+  EXPECT_NO_THROW(step_frame());
 
-    // 4. Change to Main Game Scene
-    view.changeScene(std::make_unique<MainGameScene>(&view));
-    EXPECT_NO_THROW(step_frame());
+  // 3. Change back to Main Menu
+  view.changeScene(std::make_unique<MainMenuScene>(&view));
+  EXPECT_NO_THROW(step_frame());
 
-    // Pop the implicit TeamSelectionScene overlay
-    view.popScene();
-    EXPECT_NO_THROW(step_frame());
+  // 4. Change to Main Game Scene
+  view.changeScene(std::make_unique<MainGameScene>(&view));
+  EXPECT_NO_THROW(step_frame());
 
-    // 5. Roster Scene Overlay
-    view.overlayScene(std::make_unique<RosterScene>(&view));
-    EXPECT_NO_THROW(step_frame());
+  // Pop the implicit TeamSelectionScene overlay
+  view.popScene();
+  EXPECT_NO_THROW(step_frame());
 
-    // Pop Roster Scene
-    view.popScene();
-    EXPECT_NO_THROW(step_frame());
+  // 5. Roster Scene Overlay
+  view.overlayScene(std::make_unique<RosterScene>(&view));
+  EXPECT_NO_THROW(step_frame());
 
-    // 6. Strategy Scene Overlay
-    view.overlayScene(std::make_unique<StrategyScene>(&view));
-    EXPECT_NO_THROW(step_frame());
+  // Pop Roster Scene
+  view.popScene();
+  EXPECT_NO_THROW(step_frame());
 
-    // Pop Strategy Scene
-    view.popScene();
-    EXPECT_NO_THROW(step_frame());
+  // 6. Strategy Scene Overlay
+  view.overlayScene(std::make_unique<StrategyScene>(&view));
+  EXPECT_NO_THROW(step_frame());
+
+  // Pop Strategy Scene
+  view.popScene();
+  EXPECT_NO_THROW(step_frame());
 }

--- a/test/test_player.cpp
+++ b/test/test_player.cpp
@@ -14,8 +14,8 @@
 TEST(PlayerTest, ConstructorAndGetters)
 {
   std::map<std::string, float> stats = {{"Speed", 80.0f}, {"Passing", 70.0f}};
-  Player p(1, 10, "John", "Doe", "Midfielder", Language::EN, 1000, 1, 25, 3, 180, Foot::Right,
-           stats);
+  Player p(1, 10, "John", "Doe", "Midfielder", Language::EN, 1000, 1, 25, 3,
+           180, Foot::Right, stats);
 
   EXPECT_EQ(p.getId(), 1);
   EXPECT_EQ(p.getTeamId(), 10);
@@ -29,7 +29,8 @@ TEST(PlayerTest, AgePlayerGrowth)
 {
   std::map<std::string, float> stats = {{"Speed", 80.0f}};
   // Young player
-  Player p(1, 10, "Young", "Gun", "Striker", Language::EN, 1000, 1, 20, 3, 180, Foot::Right, stats);
+  Player p(1, 10, "Young", "Gun", "Striker", Language::EN, 1000, 1, 20, 3, 180,
+           Foot::Right, stats);
 
   // If age < PLAYER_AGE_FACTOR_DECLINE_AGE (31.5), stats don't decay.
   p.agePlayer();
@@ -41,7 +42,8 @@ TEST(PlayerTest, AgePlayerDecline)
 {
   std::map<std::string, float> stats = {{"Speed", 80.0f}};
   // Old player
-  Player p(1, 10, "Old", "Guard", "Striker", Language::EN, 1000, 1, 35, 3, 180, Foot::Right, stats);
+  Player p(1, 10, "Old", "Guard", "Striker", Language::EN, 1000, 1, 35, 3, 180,
+           Foot::Right, stats);
 
   p.agePlayer();
   EXPECT_EQ(p.getAge(), 36);
@@ -52,8 +54,8 @@ TEST(PlayerTest, AgePlayerDecline)
 TEST(PlayerTest, GetOverall)
 {
   std::map<std::string, float> stats = {{"Speed", 80.0f}, {"Shooting", 90.0f}};
-  Player p(1, 10, "Striker", "Man", "Striker", Language::EN, 1000, 1, 25, 3, 180, Foot::Right,
-           stats);
+  Player p(1, 10, "Striker", "Man", "Striker", Language::EN, 1000, 1, 25, 3,
+           180, Foot::Right, stats);
 
   StatsConfig config;
   RoleFocus roleFocus;
@@ -68,8 +70,8 @@ TEST(PlayerTest, GetOverall)
 TEST(PlayerTest, Train)
 {
   std::map<std::string, float> stats = {{"Speed", 50.0f}};
-  Player p(1, 10, "Trainee", "Boy", "Striker", Language::EN, 1000, 1, 20, 3, 180, Foot::Right,
-           stats);
+  Player p(1, 10, "Trainee", "Boy", "Striker", Language::EN, 1000, 1, 20, 3,
+           180, Foot::Right, stats);
 
   // Train speed
   // Training is random, but it should increase or stay same (if random factor


### PR DESCRIPTION
Fixes #46

This PR integrates Google Benchmark to track the performance of database operations such as `GameData::loadFromDB` and `GameData::saveToDB`. 

### Changes
- Implemented `GameData::saveToDB()` functionality.
- Added `benchmarks` CMake target that leverages `google/benchmark`.
- Updated `AGENT.md` to explicitly prohibit AI agents from pushing and committing, and mandated performance testing for relevant changes.
- Updated `CONTRIBUTING.md` with explicit instructions for users and agents on how to run benchmarks locally.